### PR TITLE
Reformatted Changes as per CPAN::Changes::Spec

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,30 +1,30 @@
-Revision history for Perl extension Math::Int128.
+Revision history for Perl extension Math::Int128
 
-0.12  Jul 19, 2013
+0.12 2013-07-19
       - improve gcc version detection (bug report by
         d.thomas@its.uq.edu.au)
       - experimental support for clang compiler added
 
-0.11  Jul 18, 2013
+0.11 2013-07-18
       - fix >>= operator (patch by Dave Rolsky)
       - more and better tests (patch by Dave Rolsky)
       - easy compilation of the git version
 
-0.10  Jul 17, 2013
+0.10 2013-07-17
       - add support for exponentiation (bug report by Dave Rolsky)
 
-0.09  Jul 11, 2013
+0.09 2013-07-11
       - operator <<= was broken for unsigned 128bit numbers (bug
         report by Dave Rolsky)
 
-0.08_01
+0.08_01 unknown
       - include stdint.h for 64bit integer definitions (bug report and
         solution by Sisyphus)
 
-0.07  Dec 10, 2012
+0.07 2012-12-10
       - rerelease as stable
 
-0.06_07  Nov 5, 2012
+0.06_07 2012-11-05
       - gcc version detection was to picky (bug report by Peter John
         Acklam)
       - int128_to_net and uint128_to_net were broken
@@ -32,39 +32,39 @@ Revision history for Perl extension Math::Int128.
       - mark internal representation of int128 wrappers as readonly in
         order to disallow their modification from outside the module
 
-0.06_06  Jul 20, 2012
+0.06_06 2012-07-20
       - update Math::Int64 C API support files
 
-0.06_05  Jul 19, 2012
+0.06_05 2012-07-19
       - stash caching code was broken on non threaded perls
       - several errors on C API corrected
 
-0.06_04  Jul 17, 2012
+0.06_04 2012-07-17
       - add support for C API
       - stash caching handling was broken on threaded perls
       - improve die_on_overflow handling
 
-0.06_03  Jan 11, 2012
+0.06_03 2012-01-11
       - add die_on_overflow feature
       - add support for int64_t integers via Math::Int64 
       
-0.05  Apr 24, 2011
+0.05 2011-04-24
       - support for gcc 4.4 and 4.5 contributed by KMX
 
-0.04  Mar 8, 2011
+0.04 2011-03-08
       - delete generated Makefile when aborting Makefile.PL
 
-0.03  Mar 4, 2011
+0.03 2011-03-04
       - abort Makefile.PL unless compiler is GCC 4.6 or better
 
-0.02  Feb 14, 2011
+0.02 2011-02-14
       - add new set of operations that use one argument for output for
         improved performance
       - on string to int128 conversion skip zeros at the left before
         testing for overflow
       - remove OPTIMIZE='-g -O0' from Makefile.PL
 
-0.01  Mon Feb  7 11:14:56 2011
+0.01 2011-02-07
 	- original version; created by h2xs 1.23 with options
 		-An Math::Int128
 


### PR DESCRIPTION
Hi,

Attached is a version of your current Changes file, but reformatted according to the spec defined in CPAN::Changes::Spec

Following this format means that various tools can more easily process your distribution automatically.

You can find out more about this at Brian Cassidy's [CPAN::Changes Kwalitee Service](http://changes.cpanhq.org), which is where I saw your module listed :-)

Note: I couldn't find the date for your developer release 0.08_01 (dev releases don't seem to make it onto backpan), so I listed this as:

> 0.08_01 unknown

This is currently not supported by CPAN::Changes::Spec, but I've suggested this should be supported, for cases like this.

Cheers,
Neil
