### PR TITLE
Remove trailing whitespace

### DIFF
--- a/Changes
+++ b/Changes
@@ -122,8 +122,8 @@ Revision history for Perl extension Math::Int128.
 
 0.06_03  2012-01-11
       - add die_on_overflow feature
-      - add support for int64_t integers via Math::Int64 
-      
+      - add support for int64_t integers via Math::Int64
+
 0.05     2011-04-24
       - support for gcc 4.4 and 4.5 contributed by KMX
 

--- a/Int128.xs
+++ b/Int128.xs
@@ -547,7 +547,7 @@ powU128(pTHX_ uint128_t a, uint128_t b) {
 
 #include "c_api.h"
 
-MODULE = Math::Int128		PACKAGE = Math::Int128			PREFIX=miu128_	
+MODULE = Math::Int128		PACKAGE = Math::Int128			PREFIX=miu128_
 
 BOOT:
     init_stash_cache(aTHX);
@@ -852,7 +852,7 @@ CODE:
          ( a > 0
            ? ( (b > 0) && (INT128_MAX - a < b) )
            : ( (b < 0) && (INT128_MIN - a > b) ) ) ) overflow(aTHX_ add_error);
-    if (SvOK(rev)) 
+    if (SvOK(rev))
         RETVAL = newSVi128(aTHX_ a + b);
     else {
         RETVAL = self;
@@ -1240,7 +1240,7 @@ mi128_bnot(self, ...)
 CODE:
     RETVAL = newSVi128(aTHX_ ~SvI128x(self));
 OUTPUT:
-    RETVAL    
+    RETVAL
 
 SV *
 mi128_neg(self, ...)
@@ -1318,7 +1318,7 @@ PREINIT:
     uint128_t b = SvU128(aTHX_ other);
 CODE:
     if (may_die_on_overflow && (UINT128_MAX - a < b)) overflow(aTHX_ add_error);
-    if (SvOK(rev)) 
+    if (SvOK(rev))
         RETVAL = newSVu128(aTHX_ a + b);
     else {
         RETVAL = self;
@@ -1674,7 +1674,7 @@ mu128_bnot(self, ...)
 CODE:
     RETVAL = newSVu128(aTHX_ ~SvU128x(self));
 OUTPUT:
-    RETVAL    
+    RETVAL
 
 SV *
 mu128_neg(self, ...)
@@ -1907,7 +1907,7 @@ mi128_int128_right(self, a, b)
     uint128_t b
 CODE:
     SvI128x(self) = (b > 127 ? (a < 0 ? - 1 : 0) : a >> b);
-                  
+
 void
 mi128_int128_average(self, a, b)
     SV *self

--- a/c_api.decl
+++ b/c_api.decl
@@ -2,7 +2,7 @@
 
 
 SV *     newSVi128 (pTHX_ int128_t i128)
-SV *     newSVu128 (pTHX_ uint128_t u128) 
+SV *     newSVu128 (pTHX_ uint128_t u128)
 int128_t SvI128    (pTHX_ SV *sv)
 int128_t SvU128    (pTHX_ SV *sv)
 int      SvI128OK  (pTHX_ SV*)


### PR DESCRIPTION
This change explicitly ignores the files under `/inc` since they are
originally from other dists; the LICENSE file is also ignored since it
is automatically generated.

Some projects consider this a must, and will disallow commits to be submitted which contain trailing whitespace (the Linux kernel is an example project where trailing whitespace isn’t permitted). Other projects see whitespace cleanup as simply nit-picking. Either way, I thought I'd tidy this up, and if you don't think this is necessary, I don't mind :-).  This PR is submitted in the hope that it is useful; if you want it changed in any way, please just let me know and I'll update it and resubmit.