### PR TITLE
Add strict and warnings pragmas to syp benchmark

### DIFF
--- a/benchmarks/syp.pl
+++ b/benchmarks/syp.pl
@@ -1,3 +1,6 @@
+use strict;
+use warnings;
+
 use Math::Int128 qw(int128 :op);
 use Math::GMPz qw(:mpz);
 use Benchmark qw(:all);


### PR DESCRIPTION
Now `perlcritic` throws no warnings at the default severity level.  I've explicitly ignored the output from the `inc/` directory since these files originally come from other dists.  If you want the `perlcritic` issues fixed in these files as well, please just let me know and I'll update the PR.