### PR TITLE
Update copyright info

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-This software is copyright (c) 2014 by Salvador Fandiño.
+This software is copyright (c) 2014 - 2015 by Salvador Fandiño and Dave Rolsky.
 
 This is free software; you can redistribute it and/or modify it under
 the same terms as the Perl 5 programming language system itself.
@@ -12,7 +12,7 @@ b) the "Artistic License"
 
 --- The GNU General Public License, Version 1, February 1989 ---
 
-This software is Copyright (c) 2014 by Salvador Fandiño and Dave Rolsky.
+This software is Copyright (c) 2014 - 2015 by Salvador Fandiño and Dave Rolsky.
 
 This is free software, licensed under:
 
@@ -272,7 +272,7 @@ That's all there is to it!
 
 --- The Artistic License 1.0 ---
 
-This software is Copyright (c) 2014 by Salvador Fandiño and Dave Rolsky.
+This software is Copyright (c) 2014 - 2015 by Salvador Fandiño and Dave Rolsky.
 
 This is free software, licensed under:
 

--- a/dist.ini
+++ b/dist.ini
@@ -2,7 +2,8 @@ name    = Math-Int128
 author  = Salvador Fandino <sfandino@yahoo.com>
 author  = Dave Rolsky <autarch@urth.org>
 license = Perl_5
-copyright_holder = Salvador Fandino
+copyright_holder = Salvador Fandiño and Dave Rolsky
+copyright_year = 2014
 
 [@DROLSKY]
 :version = 0.32

--- a/lib/Math/Int128/die_on_overflow.pm
+++ b/lib/Math/Int128/die_on_overflow.pm
@@ -41,7 +41,7 @@ L<Math::Int128>.
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright E<copy> 2011, 2013 by Salvador Fandiño (sfandino@yahoo.com)
+Copyright E<copy> 2011, 2013-2015 by Salvador Fandiño (sfandino@yahoo.com)
 
 This library is free software; you can redistribute it and/or modify
 it under the same terms as Perl itself, either Perl version 5.8.8 or,


### PR DESCRIPTION
The copyright year is updated to the year of the current release (2015) and added a missing name to the copyright information, which had been partially added in an eariler commit, however not yet added to the `dist.ini`.

If you wish to have this PR changed, please just let me know and I'll update it and resubmit.