### PR TITLE
Stop ignoring LICENSE file

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -24,7 +24,6 @@ stopwords = postincrement
 stopwords = preprocessing
 stopwords = uint
 stopwords = wishlist
--remove = License
 -remove = MakeMaker
 -remove = PkgVersion
 -remove = SurgicalPodWeaver


### PR DESCRIPTION
This enables the `dzil` commands to work again, since they were
expecting the LICENSE file to exist.

For example, the error message from `dzil test` was:

```
[@DROLSKY/CopyFilesFromBuild] Cannot copy LICENSE from build: file does not exist
[@DROLSKY/CopyFilesFromBuild] Cannot copy LICENSE from build: file does not exist at /home/cochrane/perl5/perlbrew/perls/perl-5.20.3/lib/site_perl/5.20.3/x86_64-linux/Moose/Meta/Method/Delegation.pm line 110.
```

Similar output appears for `dzil build`.  This change thus allows the dist to be built and tested via the `dzil` commands again.

@salva: if you accept this change, would it then be sensible to run the `Dist::Zilla` commands directly in the Travis builds rather than using the `travis/setup.pl` script?  If so, then I can submit another PR which would replace the setup script with only the `.travis.yml` config.