### PR TITLE
Use tilde upon 'n' in author's name

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-This software is copyright (c) 2014 by Salvador Fandiño.
+This software is copyright (c) 2016 by Salvador Fandiño and Dave Rolsky.
 
 This is free software; you can redistribute it and/or modify it under
 the same terms as the Perl 5 programming language system itself.
@@ -12,7 +12,7 @@ b) the "Artistic License"
 
 --- The GNU General Public License, Version 1, February 1989 ---
 
-This software is Copyright (c) 2014 by Salvador Fandiño and Dave Rolsky.
+This software is Copyright (c) 2016 by Salvador Fandiño and Dave Rolsky.
 
 This is free software, licensed under:
 
@@ -272,7 +272,7 @@ That's all there is to it!
 
 --- The Artistic License 1.0 ---
 
-This software is Copyright (c) 2014 by Salvador Fandiño and Dave Rolsky.
+This software is Copyright (c) 2016 by Salvador Fandiño and Dave Rolsky.
 
 This is free software, licensed under:
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -11,7 +11,7 @@ use ExtUtils::MakeMaker;
 
 my %WriteMakefileArgs = (
   "ABSTRACT" => "Manipulate 128 bits integers in Perl",
-  "AUTHOR" => "Salvador Fandino <sfandino\@yahoo.com>, Dave Rolsky <autarch\@urth.org>",
+  "AUTHOR" => "Salvador Fandi\x{f1}o <sfandino\@yahoo.com>, Dave Rolsky <autarch\@urth.org>",
   "CONFIGURE_REQUIRES" => {
     "ExtUtils::MakeMaker" => 0
   },

--- a/dist.ini
+++ b/dist.ini
@@ -1,8 +1,8 @@
 name    = Math-Int128
-author  = Salvador Fandino <sfandino@yahoo.com>
+author  = Salvador Fandiño <sfandino@yahoo.com>
 author  = Dave Rolsky <autarch@urth.org>
 license = Perl_5
-copyright_holder = Salvador Fandino
+copyright_holder = Salvador Fandiño and Dave Rolsky
 
 [@DROLSKY]
 :version = 0.32


### PR DESCRIPTION
Now the ñ appears consistently within the copyright and author
statements in the distribution.

It's possible that this PR conflicts with PR #14; if you wish to merge PR #14 and conflicts with the current PR appear, please let me know and I'll fix it and resubmit.